### PR TITLE
Fix webpack bundling issue

### DIFF
--- a/lib/fetch-api.js
+++ b/lib/fetch-api.js
@@ -1,4 +1,4 @@
-const fetch = require('node-fetch');
+const fetch = require('node-fetch').default;
 const { URL, URLSearchParams } = require('url');
 const { BarionError } = require('./errors');
 

--- a/test/fetch-api.test.js
+++ b/test/fetch-api.test.js
@@ -13,13 +13,15 @@ const proxyquire = require('proxyquire').noCallThru();
 const fetchMock = require('fetch-mock');
 const { fetchTest } = require('./test-data');
 
-const barionMock = fetchMock
-                    .mock('begin:http://example.com/success', fetchTest.successResponse)
-                    .mock('begin:http://example.com/error', fetchTest.errorResponse)
-                    .mock('begin:http://example.com/internal-server-error', fetchTest.internalErrorResponse)
-                    .mock('begin:http://example.com/not-valid-json', fetchTest.notJsonResponse)
-                    .mock('begin:http://example.com/network-error', fetchTest.networkErrorResponse)
-                    .sandbox();
+const barionMock = {
+    default: fetchMock
+                .mock('begin:http://example.com/success', fetchTest.successResponse)
+                .mock('begin:http://example.com/error', fetchTest.errorResponse)
+                .mock('begin:http://example.com/internal-server-error', fetchTest.internalErrorResponse)
+                .mock('begin:http://example.com/not-valid-json', fetchTest.notJsonResponse)
+                .mock('begin:http://example.com/network-error', fetchTest.networkErrorResponse)
+                .sandbox()
+};
 
 /*
  * The module to test.


### PR DESCRIPTION
An issue is reported in 2019-03-21: node-barion was not usable in Netlify lambda functions, due to [some incompatibility issue](https://github.com/bitinn/node-fetch/issues/450) between node-fetch and webpack.

node-barion module now works properly after bundled by webpack.