### PR TITLE
Increase timeout for integration tests

### DIFF
--- a/test/integration/integration.test.js
+++ b/test/integration/integration.test.js
@@ -6,6 +6,9 @@ let Barion = require('../../'); //index.js in root level
 let testData = require('./test-data');
 
 describe('Integration tests', function () {
+
+    this.timeout(15000); 
+
     describe('Start payment', function () {
 
         let barion;


### PR DESCRIPTION
Timeout of 2s is often not enough for the integration tests, so increased it to 15s.