### PR TITLE
Update Joi to v16, refactor node-barion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 coverage
 .nyc_output
+.vscode
 test/integration/credentials.json

--- a/lib/build.js
+++ b/lib/build.js
@@ -44,7 +44,7 @@ function getCaseInsensitiveIntersection (standardKeys, untrustedKeys) {
  * @param {Object} options - User-defined values, that are override defaults.
  */
 function buildRequestWithoutValidation (schema, defaults, customs) {
-    const necessaryKeys = Object.keys(schema.describe().children);
+    const necessaryKeys = Object.keys(schema.describe().keys);
     const actualKeys = Object.keys(customs);
     const request = Object.assign({}, customs);
 
@@ -69,9 +69,11 @@ function buildRequestWithoutValidation (schema, defaults, customs) {
  * @param {Object} options - User-defined values, that are override defaults.
  */
 function buildRequest (schema, defaults, options) {
-    const schemaFields = Object.keys(schema.describe().children);
+    const schemaFields = Object.keys(schema.describe().keys);
     const immutablesInSchema = getCaseInsensitiveIntersection(schemaFields, immutableFields);
-    const validationSchema = (immutablesInSchema.length > 0) ? schema.forbiddenKeys(...immutablesInSchema) : schema;
+    const validationSchema = (immutablesInSchema.length > 0)
+        ? schema.fork(immutablesInSchema, field => field.forbidden()) // TODO: separate to function
+        : schema;
 
     const customs = sanitizeThenValidate(validationSchema, options, true);
     const merged = Object.assign({}, defaults, customs);

--- a/lib/build.js
+++ b/lib/build.js
@@ -63,6 +63,15 @@ function buildRequestWithoutValidation (schema, defaults, customs) {
 }
 
 /**
+ * Makes the given keys forbidden in the given Joi-schema.
+ * @param {Object} schema - The Joi-schema to modify.
+ * @param {String[]} forbiddenKeys - The forbidden keys.
+ */
+function setKeysForbidden (schema, forbiddenKeys) {
+    return schema.fork(forbiddenKeys, key => key.forbidden());
+}
+
+/**
  * Builds request object, that could send to the Barion API.
  * @param {Object} schema - Schema, which defines structure of the request object.
  * @param {Object} defaults - Default values from Barion instance.
@@ -71,9 +80,7 @@ function buildRequestWithoutValidation (schema, defaults, customs) {
 function buildRequest (schema, defaults, options) {
     const schemaFields = Object.keys(schema.describe().keys);
     const immutablesInSchema = getCaseInsensitiveIntersection(schemaFields, immutableFields);
-    const validationSchema = (immutablesInSchema.length > 0)
-        ? schema.fork(immutablesInSchema, field => field.forbidden()) // TODO: separate to function
-        : schema;
+    const validationSchema = (immutablesInSchema.length > 0) ? setKeysForbidden(schema, immutablesInSchema) : schema;
 
     const customs = sanitizeThenValidate(validationSchema, options, true);
     const merged = Object.assign({}, defaults, customs);

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -19,6 +19,15 @@ function marshalValidationError (error) {
 }
 
 /**
+ * Makes the given keys optional in the given Joi-schema.
+ * @param {Object} schema - The Joi-schema to modify.
+ * @param {String[]} optionalKeys - The optional keys.
+ */
+function setKeysOptional (schema, optionalKeys) {
+    return schema.fork(optionalKeys, key => key.optional());
+}
+
+/**
  * Sanitizes, then validates request object with the given schema.
  * @param {Object} schema - Schema, which defines structure of the request object.
  * @param {Object} object - The request object, that is expected to send to API.
@@ -34,7 +43,7 @@ function sanitizeThenValidate (schema, object, justSanitize) {
         optionalKeys = difference(schemaKeys, immutableFields);
     }
 
-    const validationSchema = justSanitize ? schema.fork(optionalKeys, field => field.optional()) : schema;
+    const validationSchema = justSanitize ? setKeysOptional(schema, optionalKeys) : schema;
 
     const { error, value } = validationSchema.validate(
         object,

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,6 +1,5 @@
 const { BarionModelError } = require('./errors');
 const { immutableFields } = require('./constants');
-const Joi = require('@hapi/joi');
 
 /**
  * Creates A\B (a.k.a. A-B) relation of two arrays.
@@ -31,13 +30,14 @@ function sanitizeThenValidate (schema, object, justSanitize) {
     let optionalKeys = [];
 
     if (justSanitize) { // TODO: put sanitize-only mode to other function
-        schemaKeys = Object.keys(schema.describe().children);
+        schemaKeys = Object.keys(schema.describe().keys);
         optionalKeys = difference(schemaKeys, immutableFields);
     }
 
-    const { error, value } = Joi.validate(
+    const validationSchema = justSanitize ? schema.fork(optionalKeys, field => field.optional()) : schema;
+
+    const { error, value } = validationSchema.validate(
         object,
-        justSanitize ? schema.optionalKeys(...optionalKeys) : schema,
         {
             stripUnknown: true,
             abortEarly: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,18 +133,24 @@
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
       "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
     },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+    },
     "@hapi/hoek": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-7.2.1.tgz",
-      "integrity": "sha512-X6YzLoU+VvZwUNe0VFJV/r4IiFHf61/6VItdnKjlay+YS/5qoczO3u/7wyTj2NtaOZHlFJBndNkfZ2Ag2XxCsg=="
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.1.tgz",
+      "integrity": "sha512-JPiBy+oSmsq3St7XlipfN5pNA6bDJ1kpa73PrK/zR29CVClDVqy04AanM/M/qx5bSF+I61DdCfAvRrujau+zRg=="
     },
     "@hapi/joi": {
-      "version": "16.0.0-rc1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.0.0-rc1.tgz",
-      "integrity": "sha512-I64oEaDWZA4FKzEDnoadcqB7T+p/KdIFoWpaluxPIXwffgPYxGk3EIrPVLsx6JPKzdzWgEZcCe/xni0RVF3PxA==",
+      "version": "16.0.0-preview",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.0.0-preview.tgz",
+      "integrity": "sha512-Z3ue0n3AwSKCuE7HVVTXc+vaC+YaJwT4wks6ZbS1hXjzAn/nzSHrO9qUGDhrfC3ytE6Rd+kn255AntBw2dKZWg==",
       "requires": {
         "@hapi/address": "2.x.x",
-        "@hapi/hoek": "7.x.x",
+        "@hapi/formula": "1.x.x",
+        "@hapi/hoek": "8.x.x",
         "@hapi/marker": "1.x.x",
         "@hapi/topo": "3.x.x"
       }
@@ -155,18 +161,11 @@
       "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
     },
     "@hapi/topo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.0.tgz",
-      "integrity": "sha512-gZDI/eXOIk8kP2PkUKjWu9RW8GGVd2Hkgjxyr/S7Z+JF+0mr7bAlbw+DkTRxnD580o8Kqxlnba9wvqp5aOHBww==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.3.tgz",
+      "integrity": "sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==",
       "requires": {
-        "@hapi/hoek": "6.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "6.2.4",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
-          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
-        }
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "proxyquire": "^2.1.0"
   },
   "dependencies": {
-    "@hapi/joi": "16.0.0-rc1",
+    "@hapi/joi": "16.0.0-preview",
     "node-fetch": "2.3.0"
   },
   "husky": {

--- a/test/StartPayment.schema.test.js
+++ b/test/StartPayment.schema.test.js
@@ -1,5 +1,4 @@
 const { expect } = require('chai');
-const Joi = require('@hapi/joi');
 const StartPayment = require('../lib/domain/StartPayment');
 
 const Transactions = [
@@ -45,15 +44,15 @@ describe('lib/domain/StartPayment.js', function () {
 
 
     it('should not strip ReservationPeriod field on reservation payment initialization', function () {
-        const { error, value } = Joi.validate(reservationPayment, StartPayment);
+        const { error, value } = StartPayment.validate(reservationPayment);
 
-        expect(error).to.be.null;
+        expect(error).to.be.undefined;
         expect(value).to.deep.equal(reservationStandard);
     });
 
     it('should require ReservationPeriod field on reservation payment initialization', function () {
         delete reservationPayment.ReservationPeriod;
-        const { error } = Joi.validate(reservationPayment, StartPayment);
+        const { error } = StartPayment.validate(reservationPayment);
 
         expect(error.details).to.be.an('array').and.have.lengthOf(1);
         expect(error.details[0]).to.deep.include({ message: '"ReservationPeriod" is required' });
@@ -61,16 +60,16 @@ describe('lib/domain/StartPayment.js', function () {
 
     it('should forbid ReservationPeriod field on immediate payment initialization', function () {
         immediatePayment.ReservationPeriod = '00:00:01:00';
-        const { error } = Joi.validate(immediatePayment, StartPayment);
+        const { error } = StartPayment.validate(immediatePayment);
 
         expect(error.details).to.be.an('array').and.have.lengthOf(1);
         expect(error.details[0]).to.deep.include({ message: '"ReservationPeriod" is not allowed' });
     });
 
     it('should validate correct immediate payment initialization', function () {
-        const { error, value } = Joi.validate(immediatePayment, StartPayment);
+        const { error, value } = StartPayment.validate(immediatePayment);
 
-        expect(error).to.be.null;
+        expect(error).to.be.undefined;
         expect(value).to.deep.equal(immediateStandard);
     });
 });

--- a/test/TimeSpan.schema.test.js
+++ b/test/TimeSpan.schema.test.js
@@ -1,59 +1,58 @@
 const { expect } = require('chai');
-const Joi = require('@hapi/joi');
 const TimeSpan = require('../lib/domain/common/TimeSpan');
 
 describe('lib/domain/common/TimeSpan.js', function () {
     it('should allow time span with day-dot notation (3.14:15:28)', function () {
-        const { error, value } = Joi.validate('3.14:15:28', TimeSpan);
+        const { error, value } = TimeSpan.validate('3.14:15:28');
 
-        expect(error).to.be.null;
+        expect(error).to.be.undefined;
         expect(value).to.equal('3.14:15:28');
     });
 
     it('should allow time span with day-colon notation (3:14:15:28)', function () {
-        const { error, value } = Joi.validate('3:14:15:28', TimeSpan);
+        const { error, value } = TimeSpan.validate('3:14:15:28');
 
-        expect(error).to.be.null;
+        expect(error).to.be.undefined;
         expect(value).to.equal('3:14:15:28');
     });
 
     it('should allow multi-digit days', function () {
-        const { error, value } = Joi.validate('365:14:15:28', TimeSpan);
+        const { error, value } = TimeSpan.validate('365:14:15:28');
 
-        expect(error).to.be.null;
+        expect(error).to.be.undefined;
         expect(value).to.equal('365:14:15:28');
     });
 
     it('should not allow hours greater than 23', function () {
-        const { error } = Joi.validate('365:24:15:28', TimeSpan);
+        const { error } = TimeSpan.validate('365:24:15:28');
 
         expect(error.details).to.be.an('array').and.have.lengthOf(1);
         expect(error.details[0].message).to.match(/timespan/);
     });
 
     it('should not allow minutes greater than 59', function () {
-        const { error } = Joi.validate('365:22:60:28', TimeSpan);
+        const { error } = TimeSpan.validate('365:22:60:28');
 
         expect(error.details).to.be.an('array').and.have.lengthOf(1);
         expect(error.details[0].message).to.match(/timespan/);
     });
 
     it('should not allow seconds greater than 59', function () {
-        const { error } = Joi.validate('365:22:15:60', TimeSpan);
+        const { error } = TimeSpan.validate('365:22:15:60');
 
         expect(error.details).to.be.an('array').and.have.lengthOf(1);
         expect(error.details[0].message).to.match(/timespan/);
     });
 
     it('should not allow strings with less than 4 part', function () {
-        const { error } = Joi.validate('22:15', TimeSpan);
+        const { error } = TimeSpan.validate('22:15');
 
         expect(error.details).to.be.an('array').and.have.lengthOf(1);
         expect(error.details[0].message).to.match(/timespan/);
     });
 
     it('should not allow strings with more than 4 part', function () {
-        const { error } = Joi.validate('22:15:22:22:22:22', TimeSpan);
+        const { error } = TimeSpan.validate('22:15:22:22:22:22');
 
         expect(error.details).to.be.an('array').and.have.lengthOf(1);
         expect(error.details[0].message).to.match(/timespan/);


### PR DESCRIPTION
The @hapi/joi dependency is updated to `16.0.0-preview` version. The code is refactored to succeed tests.

It closes #12 