### PR TITLE
Refactor schemas

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -1,5 +1,6 @@
 const { immutableFields } = require('./constants');
 const { sanitizeThenValidate } = require('./validate');
+const { setFieldsForbidden } = require('./schema');
 
 /**
  * Does a case-insensitive search. Returns if the value is presented in the given array.
@@ -63,15 +64,6 @@ function buildRequestWithoutValidation (schema, defaults, customs) {
 }
 
 /**
- * Makes the given keys forbidden in the given Joi-schema.
- * @param {Object} schema - The Joi-schema to modify.
- * @param {String[]} forbiddenKeys - The forbidden keys.
- */
-function setKeysForbidden (schema, forbiddenKeys) {
-    return schema.fork(forbiddenKeys, key => key.forbidden());
-}
-
-/**
  * Builds request object, that could send to the Barion API.
  * @param {Object} schema - Schema, which defines structure of the request object.
  * @param {Object} defaults - Default values from Barion instance.
@@ -80,7 +72,7 @@ function setKeysForbidden (schema, forbiddenKeys) {
 function buildRequest (schema, defaults, options) {
     const schemaFields = Object.keys(schema.describe().keys);
     const immutablesInSchema = getCaseInsensitiveIntersection(schemaFields, immutableFields);
-    const validationSchema = (immutablesInSchema.length > 0) ? setKeysForbidden(schema, immutablesInSchema) : schema;
+    const validationSchema = (immutablesInSchema.length > 0) ? setFieldsForbidden(schema, immutablesInSchema) : schema;
 
     const customs = sanitizeThenValidate(validationSchema, options, true);
     const merged = Object.assign({}, defaults, customs);

--- a/lib/domain/BankTransfer.js
+++ b/lib/domain/BankTransfer.js
@@ -1,4 +1,6 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../schema');
+
 const BankAccount = require('./common/BankAccount');
 const constraints = require('./_constraints');
 
@@ -19,13 +21,6 @@ const schema = Joi.object({
     Comment: Joi.string().optional()
         .max(90),
     BankAccount: BankAccount.required()
-})
-    .rename(/^UserName$/i, 'UserName', { override: true })
-    .rename(/^Password$/i, 'Password', { override: true })
-    .rename(/^Currency$/i, 'Currency', { override: true })
-    .rename(/^Amount$/i, 'Amount', { override: true })
-    .rename(/^RecipientName$/i, 'RecipientName', { override: true })
-    .rename(/^Comment$/i, 'Comment', { override: true })
-    .rename(/^BankAccount$/i, 'BankAccount', { override: true });
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/FinishReservation.js
+++ b/lib/domain/FinishReservation.js
@@ -1,4 +1,6 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../schema');
+
 const TransactionToFinish = require('./common/TransactionToFinish');
 
 /**
@@ -14,9 +16,6 @@ const schema = Joi.object({
     Transactions: Joi.array().required()
         .items(TransactionToFinish)
         .min(1)
-})
-    .rename(/^POSKey$/i, 'POSKey', { override: true })
-    .rename(/^PaymentId$/i, 'PaymentId', { override: true })
-    .rename(/^Transactions$/i, 'Transactions', { override: true });
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/GetPaymentState.js
+++ b/lib/domain/GetPaymentState.js
@@ -1,4 +1,5 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../schema');
 
 /**
  * Used to query the details and current state of a given payment.
@@ -10,8 +11,6 @@ const schema = Joi.object({
         .guid(),
     PaymentId: Joi.string().required()
         .guid()
-})
-    .rename(/^POSKey$/i, 'POSKey', { override: true })
-    .rename(/^PaymentId$/i, 'PaymentId', { override: true });
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/InitialOptions.js
+++ b/lib/domain/InitialOptions.js
@@ -1,4 +1,6 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../schema');
+
 const constraints = require('./_constraints');
 
 /**
@@ -26,13 +28,6 @@ const schema = Joi.object({
         .default('HUF'),
     ValidateModels: Joi.boolean().optional()
         .default(true)
-})
-    .rename(/^POSKey$/i, 'POSKey', { override: true })
-    .rename(/^Environment$/i, 'Environment', { override: true })
-    .rename(/^FundingSources$/i, 'FundingSources', { override: true })
-    .rename(/^GuestCheckOut$/i, 'GuestCheckOut', { override: true })
-    .rename(/^Locale$/i, 'Locale', { override: true })
-    .rename(/^Currency$/i, 'Currency', { override: true })
-    .rename(/^ValidateModels$/i, 'ValidateModels', { override: true });
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/PaymentRefund.js
+++ b/lib/domain/PaymentRefund.js
@@ -1,4 +1,6 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../schema');
+
 const TransactionToRefund = require('./common/TransactionToRefund');
 
 /**
@@ -13,9 +15,6 @@ const schema = Joi.object({
         .guid(),
     TransactionsToRefund: Joi.array().required()
         .items(TransactionToRefund)
-})
-    .rename(/^POSKey$/i, 'POSKey', { override: true })
-    .rename(/^PaymentId$/i, 'PaymentId', { override: true })
-    .rename(/^TransactionsToRefund$/i, 'TransactionsToRefund', { override: true });
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/SendTransfer.js
+++ b/lib/domain/SendTransfer.js
@@ -1,4 +1,6 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../schema');
+
 const constraints = require('./_constraints');
 
 /**
@@ -18,12 +20,6 @@ const schema = Joi.object({
         .email(),
     Comment: Joi.string().optional()
         .max(1000)
-})
-    .rename(/^UserName$/i, 'UserName', { override: true })
-    .rename(/^Password$/i, 'Password', { override: true })
-    .rename(/^Currency$/i, 'Currency', { override: true })
-    .rename(/^Amount$/i, 'Amount', { override: true })
-    .rename(/^Recipient$/i, 'Recipient', { override: true })
-    .rename(/^Comment$/i, 'Comment', { override: true });
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/StartPayment.js
+++ b/lib/domain/StartPayment.js
@@ -1,4 +1,6 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../schema');
+
 const TimeSpan = require('./common/TimeSpan');
 const ShippingAddress = require('./common/ShippingAddress');
 const PaymentTransaction = require('./common/PaymentTransaction');
@@ -50,24 +52,6 @@ const schema = Joi.object({
     PayerPhoneNumber: Joi.string().optional()
         .max(30)
         .regex(/^[0-9]{1,}$/, 'mobile')
-})
-    .rename(/^POSKey$/i, 'POSKey', { override: true })
-    .rename(/^PaymentType$/i, 'PaymentType', { override: true })
-    .rename(/^ReservationPeriod$/i, 'ReservationPeriod', { override: true })
-    .rename(/^PaymentWindow$/i, 'PaymentWindow', { override: true })
-    .rename(/^GuestCheckOut$/i, 'GuestCheckOut', { override: true })
-    .rename(/^InitiateRecurrence$/i, 'InitiateRecurrence', { override: true })
-    .rename(/^RecurrenceId$/i, 'RecurrenceId', { override: true })
-    .rename(/^FundingSources$/i, 'FundingSources', { override: true })
-    .rename(/^PaymentRequestId$/i, 'PaymentRequestId', { override: true })
-    .rename(/^PayerHint$/i, 'PayerHint', { override: true })
-    .rename(/^RedirectUrl$/i, 'RedirectUrl', { override: true })
-    .rename(/^CallbackUrl$/i, 'CallbackUrl', { override: true })
-    .rename(/^Transactions$/i, 'Transactions', { override: true })
-    .rename(/^OrderNumber$/i, 'OrderNumber', { override: true })
-    .rename(/^ShippingAddress$/i, 'ShippingAddress', { override: true })
-    .rename(/^Locale$/i, 'Locale', { override: true })
-    .rename(/^Currency$/i, 'Currency', { override: true })
-    .rename(/^PayerPhoneNumber$/i, 'PayerPhoneNumber', { override: true });
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/common/BankAccount.js
+++ b/lib/domain/common/BankAccount.js
@@ -1,4 +1,5 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../../schema');
 
 /**
  * This structure represents a bank account that is used as
@@ -22,13 +23,6 @@ const schema = Joi.object({
     SwiftCode: Joi.string().optional()
         .min(8)
         .max(11)
-})
-    .rename(/^Country$/i, 'Country', { override: true })
-    .rename(/^Format$/i, 'Format', { override: true })
-    .rename(/^AccountNumber$/i, 'AccountNumber', { override: true })
-    .rename(/^Address$/i, 'Address', { override: true })
-    .rename(/^BankName$/i, 'BankName', { override: true })
-    .rename(/^BankAddress$/i, 'BankAddress', { override: true })
-    .rename(/^SwiftCode$/i, 'SwiftCode', { override: true });
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/common/Item.js
+++ b/lib/domain/common/Item.js
@@ -1,4 +1,5 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../../schema');
 
 /**
  * This structure represents an included in a payment transaction. An item can describe a product or service.
@@ -19,14 +20,6 @@ const schema = Joi.object({
     ItemTotal: Joi.number().required(),
     SKU: Joi.string().optional()
         .max(100)
-})
-    .rename(/^Name$/i, 'Name', { override: true })
-    .rename(/^Description$/i, 'Description', { override: true })
-    .rename(/^ImageUrl$/i, 'ImageUrl', { override: true })
-    .rename(/^Quantity$/i, 'Quantity', { override: true })
-    .rename(/^Unit$/i, 'Unit', { override: true })
-    .rename(/^UnitPrice$/i, 'UnitPrice', { override: true })
-    .rename(/^ItemTotal$/i, 'ItemTotal', { override: true })
-    .rename(/^SKU$/i, 'SKU', { override: true });
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/common/PayeeTransaction.js
+++ b/lib/domain/common/PayeeTransaction.js
@@ -1,4 +1,5 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../../schema');
 
 /**
  * This structure represents payee transaction included in a payment transaction.
@@ -16,10 +17,6 @@ const schema = Joi.object({
         .greater(0),
     Comment: Joi.string().optional()
         .max(640)
-})
-    .rename(/^POSTransactionId$/i, 'POSTransactionId', { override: true })
-    .rename(/^Payee$/i, 'Payee', { override: true })
-    .rename(/^Total$/i, 'Total', { override: true })
-    .rename(/^Comment$/i, 'Comment', { override: true });
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/common/PaymentTransaction.js
+++ b/lib/domain/common/PaymentTransaction.js
@@ -1,4 +1,6 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../../schema');
+
 const PayeeTransaction = require('./PayeeTransaction');
 const Item = require('./Item');
 
@@ -17,13 +19,7 @@ const schema = Joi.object({
     PayeeTransactions: Joi.array().optional()
         .items(PayeeTransaction),
     Items: Joi.array().optional()
-        .items(Item),
-})
-    .rename(/^POSTransactionId$/i, 'POSTransactionId', { override: true })
-    .rename(/^Payee$/i, 'Payee', { override: true })
-    .rename(/^Total$/i, 'Total', { override: true })
-    .rename(/^Comment$/i, 'Comment', { override: true })
-    .rename(/^PayeeTransactions$/i, 'PayeeTransactions', { override: true })
-    .rename(/^Items$/i, 'Items', { override: true });
+        .items(Item)
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/common/ShippingAddress.js
+++ b/lib/domain/common/ShippingAddress.js
@@ -1,4 +1,5 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../../schema');
 
 /**
  * This structure represents a shipping address related to a payment.
@@ -17,15 +18,6 @@ const schema = Joi.object({
     Street2: Joi.string().optional(),
     FullName: Joi.string().optional(),
     Phone: Joi.string().optional()
-})
-    .rename(/^DeliveryMethod$/i, 'DeliveryMethod', { override: true })
-    .rename(/^Country$/i, 'Country', { override: true })
-    .rename(/^City$/i, 'City', { override: true })
-    .rename(/^Region$/i, 'Region', { override: true })
-    .rename(/^Zip$/i, 'Zip', { override: true })
-    .rename(/^Street$/i, 'Street', { override: true })
-    .rename(/^Street2$/i, 'Street2', { override: true })
-    .rename(/^FullName$/i, 'FullName', { override: true })
-    .rename(/^Phone$/i, 'Phone', { override: true });
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/common/TimeSpan.js
+++ b/lib/domain/common/TimeSpan.js
@@ -1,4 +1,5 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../../schema');
 
 /**
  * A time range value represented in a string format of the ISO-8601 standard,
@@ -8,4 +9,4 @@ const Joi = require('@hapi/joi');
  */
 const schema = Joi.string().regex(/^[0-9]{1,}(\.|:)(0[0-9]|1[0-9]|2[0-3]):[0-5]{1}[0-9]{1}:[0-5]{1}[0-9]{1}$/, 'timespan');
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/common/TransactionToFinish.js
+++ b/lib/domain/common/TransactionToFinish.js
@@ -1,4 +1,6 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../../schema');
+
 const PayeeTransaction = require('./PayeeTransaction');
 const Item = require('./Item');
 
@@ -17,11 +19,6 @@ const schema = Joi.object({
         .items(PayeeTransaction),
     Items: Joi.array().optional()
         .items(Item)
-})
-    .rename(/^TransacionId$/i, 'TransacionId', { override: true })
-    .rename(/^Total$/i, 'Total', { override: true })
-    .rename(/^Comment$/i, 'Comment', { override: true })
-    .rename(/^PayeeTransactions$/i, 'PayeeTransactions', { override: true })
-    .rename(/^Items$/i, 'Items', { override: true });
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/domain/common/TransactionToRefund.js
+++ b/lib/domain/common/TransactionToRefund.js
@@ -1,4 +1,5 @@
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../../schema');
 
 /**
  * This structure represents a payment transaction that is to be refunded completely or partially.
@@ -13,10 +14,6 @@ const schema = Joi.object({
     AmountToRefund: Joi.number().required()
         .greater(0),
     Comment: Joi.string().optional()
-})
-    .rename(/^TransactionId$/i, 'TransactionId', { override: true })
-    .rename(/^POSTransactionId$/i, 'POSTransactionId', { override: true })
-    .rename(/^AmountToRefund$/i, 'AmountToRefund', { override: true })
-    .rename(/^Comment$/i, 'Comment', { override: true });
+});
 
-module.exports = schema;
+module.exports = new CaseInsensitiveSchema(schema);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,0 +1,50 @@
+/**
+ * Makes the given keys optional in the given Joi-schema.
+ * @param {Object} schema - The Joi-schema object to modify.
+ * @param {String[]} optionalFields - The optional keys.
+ */
+function setFieldsOptional (schema, optionalFields) {
+    return schema.fork(optionalFields, field => field.optional());
+}
+
+/**
+ * Makes the given keys forbidden in the given Joi-schema.
+ * @param {Object} schema - The Joi-schema to modify.
+ * @param {String[]} forbiddenFields - The forbidden keys.
+ */
+function setFieldsForbidden (schema, forbiddenFields) {
+    return schema.fork(forbiddenFields, field => field.forbidden());
+}
+
+/**
+ * Creates case-insensitive regexp pattern to the given string.
+ * @param {String} str - The given string.
+ */
+function getCaseInsensitiveRegExp (str) {
+    return new RegExp(`^${str}$`, 'i');
+}
+
+/**
+ * Makes a schema case-insensitive to field naming (e.g. name, Name and NaMe can be used in objects).
+ * @param {Object} schema - The schema to modify.
+ */
+function CaseInsensitiveSchema (schema) { // TODO: do not mutate input
+    // TODO: switch back to the implementation commented out, when Joi will be fixed:
+    // https://github.com/hapijs/joi/issues/2068
+
+    // const schemaConfig = schema.describe();
+    // const keys = schemaConfig.keys ? Object.keys(schemaConfig.keys) : [];
+    const keys = [ ...schema._ids._map.keys() ];
+
+    for (const key of keys) {
+        schema = schema.rename(getCaseInsensitiveRegExp(key), key, { override: true });
+    }
+
+    return schema;
+}
+
+module.exports = {
+    setFieldsOptional,
+    setFieldsForbidden,
+    CaseInsensitiveSchema
+};

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,5 +1,6 @@
 const { BarionModelError } = require('./errors');
 const { immutableFields } = require('./constants');
+const { setFieldsOptional } = require('./schema');
 
 /**
  * Creates A\B (a.k.a. A-B) relation of two arrays.
@@ -19,15 +20,6 @@ function marshalValidationError (error) {
 }
 
 /**
- * Makes the given keys optional in the given Joi-schema.
- * @param {Object} schema - The Joi-schema to modify.
- * @param {String[]} optionalKeys - The optional keys.
- */
-function setKeysOptional (schema, optionalKeys) {
-    return schema.fork(optionalKeys, key => key.optional());
-}
-
-/**
  * Sanitizes, then validates request object with the given schema.
  * @param {Object} schema - Schema, which defines structure of the request object.
  * @param {Object} object - The request object, that is expected to send to API.
@@ -43,7 +35,7 @@ function sanitizeThenValidate (schema, object, justSanitize) {
         optionalKeys = difference(schemaKeys, immutableFields);
     }
 
-    const validationSchema = justSanitize ? setKeysOptional(schema, optionalKeys) : schema;
+    const validationSchema = justSanitize ? setFieldsOptional(schema, optionalKeys) : schema;
 
     const { error, value } = validationSchema.validate(
         object,

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1,0 +1,108 @@
+const Joi = require('@hapi/joi');
+const schemaUtils = require('../lib/schema');
+const expect = require('chai').expect;
+
+describe('lib/schema.js', function () {
+
+    let schema;
+    const { setFieldsOptional, setFieldsForbidden, CaseInsensitiveSchema } = schemaUtils;
+
+    beforeEach(() => {
+        schema = Joi.object({
+            id: Joi.number().required(),
+            name: Joi.string().required(),
+            age: Joi.number().required()
+        });
+    });
+
+    describe('#setFieldsOptional(schema, optionalFields)', function () {
+        it('should not mutate the given object', function () {
+            const result = setFieldsOptional(schema, [ 'id', 'name' ]);
+            expect(result).to.not.equals(schema);
+        });
+
+        it('should set the given fields optional', function () {
+            const validationSchema = setFieldsOptional(schema, [ 'id' ]);
+            const object = {
+                name: 'Mallory',
+                age: -666
+            };
+
+            const { error } = validationSchema.validate(object);
+            expect(error).to.be.undefined;
+        });
+
+        it('should not set fields that are not passed as optional', function () {
+            const validationSchema = setFieldsOptional(schema, [ 'id' ]);
+            const object = {
+                id: 1,
+                age: 66
+            };
+
+            const { error } = validationSchema.validate(object);
+            expect(error.details).to.be.an('array').and.have.lengthOf(1);
+            expect(error.details[0].message).to.match(/name.*is required/);
+        });
+    });
+
+    describe('#setFieldsForbidden(schema, optionalFields)', function () {
+        it('should not mutate the given object', function () {
+            const result = setFieldsForbidden(schema, [ 'id', 'name' ]);
+            expect(result).to.not.equals(schema);
+        });
+
+        it('should set the given fields forbidden', function () {
+            const validationSchema = setFieldsForbidden(schema, [ 'id' ]);
+            const object = {
+                id: 1,
+                name: 'Mallory',
+                age: -666
+            };
+
+            const { error } = validationSchema.validate(object);
+            expect(error.details).to.be.an('array').and.have.lengthOf(1);
+            expect(error.details[0].message).to.match(/id.*is not allowed/);
+        });
+
+        it('should not set fields that are not passed as forbidden', function () {
+            const validationSchema = setFieldsForbidden(schema, [ 'id' ]);
+            const object = {
+                name: 'Mallory',
+                age: -666
+            };
+
+            const { error } = validationSchema.validate(object);
+            expect(error).to.be.undefined;
+        });
+    });
+
+    describe('#CaseInSensitiveSchema(schema)', function() {
+        it('should ignore schemas that are not objects', function () {
+            const stringSchema = Joi.string().required();
+            const result = new CaseInsensitiveSchema(stringSchema);
+            expect(result).to.deep.equal(stringSchema);
+        });
+
+        it('should not mutate the given object', function () {
+            const result = new CaseInsensitiveSchema(schema);
+            expect(result).to.not.equal(schema);
+        });
+
+        it('should set all fields of schema case-insensitive', function () {
+            const schemaToUse = new CaseInsensitiveSchema(schema);
+            const object = {
+                iD: 1,
+                Name: 'Bob',
+                aGe: 12
+            };
+
+            const { error, value } = schemaToUse.validate(object);
+            expect(error).to.be.undefined;
+            expect(value).to.deep.equal({
+                id: 1,
+                name: 'Bob',
+                age:12
+            });
+        });
+    });
+});

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -1,18 +1,17 @@
 const { expect } = require('chai');
 const Joi = require('@hapi/joi');
+const { CaseInsensitiveSchema } = require('../lib/schema');
 
 const validation = require('../lib/validate');
 
-const validationSchema = Joi.object({
-    id: Joi.string().optional(),
-    name: Joi.string().required(),
-    gender: Joi.string().required(),
-    age: Joi.number().optional()
-})
-    .rename(/^id$/i, 'id', { override: true })
-    .rename(/^name$/i, 'name', { override: true })
-    .rename(/^gender$/i, 'gender', { override: true })
-    .rename(/^age$/i, 'age', { override: true });
+const validationSchema = new CaseInsensitiveSchema(
+    Joi.object({
+        id: Joi.string().optional(),
+        name: Joi.string().required(),
+        gender: Joi.string().required(),
+        age: Joi.number().optional()
+    })
+);
 
 describe('lib/validate.js', function () {
     describe('#sanitizeThenValidate(schema, object)', function () {


### PR DESCRIPTION
- Delete redundant rename() calls, put renames to schemas programmatically instead
- Add tests of new `schema.js` module