### PR TITLE
Fix misspelling for the word 'occurred'

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ There are 3 main types of errors can thrown, when you use the ``node-barion`` mo
 
     This error has an ``errors`` array, which contains the returned errors as strings.
 
-  - ``Other errors``: Common Javascript errors, such as ``Error`` or ``TypeError`` (thrown e.g. when network error occured).
+  - ``Other errors``: Common Javascript errors, such as ``Error`` or ``TypeError`` (thrown e.g. when network error occurred).
 
 #### Usage example
 You can distinguish types of errors based on their names, but it is not a must. Instead, you can simply log them to somewhere without any condition checking.


### PR DESCRIPTION
Fix misspelling for the word **occurred** in the Handle errors section it was spelled incorrectly as **occured**

Last PR overall the document grammar is great. Not bad for English being your second language. Happy Hacktoberfest!