### PR TITLE
Use Basic Authentication for sending username and password

### DIFF
--- a/lib/barion.js
+++ b/lib/barion.js
@@ -44,7 +44,7 @@ function doRequestAndReturn (options, callback) {
     const { defaults, customs, schema, service } = options;
     let request = {};
 
-    if (defaults.ValidateModels) {
+    if (defaults.Secure) {
         try {
             request = buildRequest(schema, defaults, customs);
         } catch (err) {
@@ -70,6 +70,7 @@ function doRequestAndReturn (options, callback) {
  * Initializes a Barion object, that represents a merchant with a given POSKey.
  * @param {Object} options - Default values for Barion API requests.
  * @param {String} options.Environment - The Barion environment to use ('test' or 'prod'). (default: 'test')
+ * @param {Boolean} options.Secure - Indicates whether the module should sanitize and validate input before sending to the Barion API. When set to *false*, the module does not do any validation, and can send private data (such as username and password) in query parameters, rather than in HTTP headers. (default: true)
  * @param {String[]} options.FundingSources - The default funding sources. (default: [ 'All' ])
  * @param {Boolean} options.GuestCheckOut - Indicates if guest checkout is enabled. (default: true)
  * @param {String} options.Locale - Localization of Barion GUI. (default: 'hu-HU')

--- a/lib/domain/InitialOptions.js
+++ b/lib/domain/InitialOptions.js
@@ -26,7 +26,7 @@ const schema = Joi.object({
     Currency: Joi.string().optional()
         .valid(...constraints.Currency)
         .default('HUF'),
-    ValidateModels: Joi.boolean().optional()
+    Secure: Joi.boolean().optional()
         .default(true)
 });
 

--- a/lib/fetch-api.js
+++ b/lib/fetch-api.js
@@ -28,12 +28,8 @@ function stripUndefined(object) {
  * @param {String} password - Password to authenticate with.
  */
 function getBasicAuthString(userName, password) {
-    if (userName && password) {
-        const buffer = Buffer.from(`${userName}:${password}`);
-        return `Basic ${buffer.toString('base64')}`;
-    }
-
-    return null;
+    const buffer = Buffer.from(`${userName}:${password}`);
+    return `Basic ${buffer.toString('base64')}`;
 }
 
 /**

--- a/lib/fetch-api.js
+++ b/lib/fetch-api.js
@@ -6,7 +6,7 @@ const { BarionError } = require('./errors');
  * Handles errors during fetch.
  * @param {Error} err - The error that should have been handled.
  */
-function handleError (err) {
+function handleError(err) {
     throw err;
 }
 
@@ -14,7 +14,7 @@ function handleError (err) {
  * Deletes undefined fields from an object.
  * @param {Object} object - The object to strip undefined values from.
  */
-function stripUndefined (object) {
+function stripUndefined(object) {
     for (const key in object) {
         if (object[key] === undefined) {
             delete object[key];
@@ -23,10 +23,70 @@ function stripUndefined (object) {
 }
 
 /**
+ * Returns the string used for basic authentication.
+ * @param {String} userName - Username to authenticate with.
+ * @param {String} password - Password to authenticate with.
+ */
+function getBasicAuthString(userName, password) {
+    if (userName && password) {
+        const buffer = Buffer.from(`${userName}:${password}`);
+        return `Basic ${buffer.toString('base64')}`;
+    }
+
+    return null;
+}
+
+/**
+ * Sets basic authentication.
+ * @param {Object} options - Fetch options.
+ * @param {String} credentials.userName - Username of the user.
+ * @param {String} credentials.password - Password of the user.
+ */
+function setBasicAuthentication(options, credentials) {
+    if (!credentials || !credentials.userName || !credentials.password) {
+        return options;
+    }
+
+    options = options || {};
+    if (!Object.prototype.hasOwnProperty.call(options, 'headers')) {
+        options.headers = {};
+    }
+
+    options.headers['Authorization'] = getBasicAuthString(credentials.userName, credentials.password);
+    return options;
+}
+
+/**
+ * Returns credentials from request params or body.
+ * @param {Object} params - Request params.
+ */
+function getCredentials(params) {
+    if (!params || !params.UserName || !params.Password) {
+        return;
+    }
+
+    return {
+        userName: params.UserName,
+        password: params.Password
+    };
+}
+
+/**
+ * Deletes credentials from request parameters.
+ * @param {Object} params - Parameters of the request.
+ */
+function deleteCredentials(params) {
+    if (params) {
+        delete params['UserName'];
+        delete params['Password'];
+    }
+}
+
+/**
  * Checks that response is binary or not.
  * @param {Object} res - Response data from Barion API.
  */
-function isBinaryResponse (res) {
+function isBinaryResponse(res) {
     return res.Buffer instanceof Buffer;
 }
 
@@ -34,7 +94,7 @@ function isBinaryResponse (res) {
  * Checks that response does contain error indicator field or not.
  * @param {Object} res - Response data from Barion API.
  */
-function containsErrorIndicator (res) {
+function containsErrorIndicator(res) {
     return res.Errors || res.ErrorList;
 }
 
@@ -42,7 +102,7 @@ function containsErrorIndicator (res) {
  * Checks that response does contain v2 API-style error.
  * @param {Object} res - Response data from Barion API.
  */
-function hasV2Errors (res) {
+function hasV2Errors(res) {
     return res.Errors && res.Errors.length > 0;
 }
 
@@ -50,7 +110,7 @@ function hasV2Errors (res) {
  * Checks that response does contain v1 API-style error.
  * @param {Object} res - Response data from Barion API.
  */
-function hasV1Errors (res) {
+function hasV1Errors(res) {
     return res.ErrorList && res.ErrorList.length > 0;
 }
 
@@ -58,7 +118,7 @@ function hasV1Errors (res) {
  * Checks if response from Barion indicates error.
  * @param {Object} res - Response data from Barion API.
  */
-function isErrorResponse (res) {
+function isErrorResponse(res) {
     return !isBinaryResponse(res) && (!containsErrorIndicator(res) || hasV2Errors(res) || hasV1Errors(res));
 }
 
@@ -69,8 +129,10 @@ function isErrorResponse (res) {
  * @returns {Promise} Promise with the response.
  * @throws {BarionError}
  */
-function fetchBarion (url, options, binary = false) {
+function fetchBarion(url, options, credentials, binary = false) {
     let success;
+
+    options = setBasicAuthentication(options, credentials);
 
     return fetch(url, options)
         .then(res => {
@@ -103,11 +165,15 @@ function fetchBarion (url, options, binary = false) {
  * @param {Object} params - Query params of the endpoint.
  * @returns {Promise} Promise with the response.
  */
-function getFromBarion (url, params) {
+function getFromBarion(url, params) {
     stripUndefined(params);
+    const credentials = getCredentials(params);
+    deleteCredentials(params);
+
     url = new URL(url);
     url.search = new URLSearchParams(params).toString();
-    return fetchBarion(url);
+
+    return fetchBarion(url, undefined, credentials);
 }
 
 /**
@@ -116,11 +182,14 @@ function getFromBarion (url, params) {
  * @param {Object} params - Search params of the endpoint.
  * @returns {Promise} Promise with the response (Buffer).
  */
-function getBinaryFromBarion (url, params) {
+function getBinaryFromBarion(url, params) {
     stripUndefined(params);
+    const credentials = getCredentials(params);
+    deleteCredentials(params);
+
     url = new URL(url);
     url.search = new URLSearchParams(params).toString();
-    return fetchBarion(url, undefined, true);
+    return fetchBarion(url, undefined, credentials, true);
 }
 
 /**
@@ -129,16 +198,22 @@ function getBinaryFromBarion (url, params) {
  * @param {Object} body - Body of the request.
  * @returns {Promise} Promise with the response.
  */
-function postToBarion (url, body) {
+function postToBarion(url, body) {
     url = new URL(url);
+    const credentials = getCredentials(body);
+    deleteCredentials(body);
 
-    return fetchBarion(url, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
+    return fetchBarion(
+        url,
+        {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(body)
         },
-        body: JSON.stringify(body)
-    });
+        credentials
+    );
 }
 
 module.exports = {

--- a/test/barion.test.js
+++ b/test/barion.test.js
@@ -145,7 +145,7 @@ describe('lib/barion.js', function () {
 
     const okBarionWithoutValidation = new Barions.OkBarion({
         POSKey: '277a6ae1-12b0-4192-8e6c-bc7d0612afa1',
-        ValidateModels: false
+        Secure: false
     });
 
     const serviceErrorBarion = new Barions.ServiceErrorBarion({
@@ -158,7 +158,7 @@ describe('lib/barion.js', function () {
 
     const sanitizationErrorBarion = new Barions.SanitizationErrorBarion({
         POSKey: '277a6ae1-12b0-4192-8e6c-bc7d0612afa1',
-        ValidateModels: false
+        Secure: false
     });
 
     describe('#startPayment(options, [callback])', function () {

--- a/test/fetch-api.test.js
+++ b/test/fetch-api.test.js
@@ -88,13 +88,27 @@ describe('lib/fetch-api.js', function () {
         });
 
         it('should resolve with data after successful response', function () {
-            return expect(getFromBarion('http://example.com/success', { a: 'b', c: 5}))
+            return expect(getFromBarion('http://example.com/success', { a: 'b', c: 5 }))
                 .to.eventually.deep.include(fetchTest.successResponse);
         });
 
         it('should resolve with data after successful response in v1 API', function () {
-            return expect(getFromBarion('http://example.com/v1-success', { a: 'b', c: 5}))
+            return expect(getFromBarion('http://example.com/v1-success', { a: 'b', c: 5 }))
                 .to.eventually.deep.include(fetchTest.v1SuccessResponse);
+        });
+
+        it('should use credentials for Basic Authentication', async function () {
+            await getFromBarion('http://example.com/success', { UserName: 'a', Password: 'b', Extra: true });
+            expect(barionMock.default.lastOptions()).to.deep.include({
+                headers: {
+                    Authorization: 'Basic YTpi' // base64-encoded a:b
+                }
+            });
+        });
+
+        it('should not use credentials in query parameters', async function () {
+            await getFromBarion('http://example.com/success', { UserName: 'a', Password: 'b', Extra: true });
+            expect(barionMock.default.lastUrl()).to.equal('http://example.com/success?Extra=true');
         });
     });
 
@@ -144,6 +158,20 @@ describe('lib/fetch-api.js', function () {
             const res = await getBinaryFromBarion('http://example.com/binary-success');
             expect(fetchTest.binarySuccessResponse.headers['Content-Type']).to.equal(res.Type);
         });
+
+        it('should use credentials for Basic Authentication', async function () {
+            await getBinaryFromBarion('http://example.com/success', { UserName: 'a', Password: 'b', Extra: true });
+            expect(barionMock.default.lastOptions()).to.deep.include({
+                headers: {
+                    Authorization: 'Basic YTpi' // base64-encoded a:b
+                }
+            });
+        });
+
+        it('should not use credentials in query parameters', async function () {
+            await getBinaryFromBarion('http://example.com/success', { UserName: 'a', Password: 'b', Extra: true });
+            expect(barionMock.default.lastUrl()).to.equal('http://example.com/success?Extra=true');
+        });
     });
 
     describe('#postToBarion()', function () {
@@ -188,13 +216,28 @@ describe('lib/fetch-api.js', function () {
         });
 
         it('should resolve data after successful response', function () {
-            return expect(postToBarion('http://example.com/success', { a: 'b', c: 5}))
+            return expect(postToBarion('http://example.com/success', { a: 'b', c: 5 }))
                 .to.eventually.deep.include(fetchTest.successResponse);
         });
 
         it('should resolve with data after successful response in v1 API', function () {
-            return expect(postToBarion('http://example.com/v1-success', { a: 'b', c: 5}))
+            return expect(postToBarion('http://example.com/v1-success', { a: 'b', c: 5 }))
                 .to.eventually.deep.include(fetchTest.v1SuccessResponse);
+        });
+
+        it('should use credentials for Basic Authentication', async function () {
+            await postToBarion('http://example.com/success', { UserName: 'a', Password: 'b', Extra: true });
+            expect(barionMock.default.lastOptions()).to.deep.include({
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': 'Basic YTpi' // base64-encoded a:b
+                }
+            });
+        });
+
+        it('should not use credentials in request body', async function () {
+            await postToBarion('http://example.com/success', { UserName: 'a', Password: 'b', Extra: true });
+            expect(barionMock.default.lastOptions()).to.deep.include({ body: '{"Extra":true}' });
         });
     });
 });

--- a/test/integration/test-data.js
+++ b/test/integration/test-data.js
@@ -16,12 +16,12 @@ module.exports = {
         withValidation: {
             POSKey,
             Environment: 'test',
-            ValidateModels: true
+            Secure: true
         },
         withoutValidation: {
             POSKey,
             Environment: 'test',
-            ValidateModels: false
+            Secure: false
         }
     },
     startPayment: {


### PR DESCRIPTION
- Use Basic Authentication for sending username and password, when prevalidation is turned on
- Change `ValidateModels` field name to `Secure`
- Document handling of credentials in Secure Mode and Insecure Mode

It closes #37 