### PR TITLE
Update TransactionToFinish.js

### DIFF
--- a/lib/domain/common/TransactionToFinish.js
+++ b/lib/domain/common/TransactionToFinish.js
@@ -13,7 +13,7 @@ const schema = Joi.object({
     TransactionId: Joi.string().required()
         .guid(),
     Total: Joi.number().required()
-        .greater(0),
+        .greater(-1),
     Comment: Joi.string().optional(),
     PayeeTransactions: Joi.array().optional()
         .items(PayeeTransaction),


### PR DESCRIPTION
Closing with zero must also be accepted

Barion documentation:
When using facilitated payments, refund is a special case. As long as a reservation payment is not finished, the facilitator has complete control of the process and is able to refund the amount by finishing the payment transactions with zero amount. However, in case of a completed immediate or a finished reservation payment, the facilitator no longer has control over the process. This means that incurring refunds must be done by the seller. The facilitator and the seller must ensure the legal compliance of this in their respective environment.